### PR TITLE
Support the use of IAM instance profiles when connecting to AWS EC2 API

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,9 @@ default:
   aws_secret_access_key: <YOUR_SECRET_ACCESS_KEY>
 ```
 
+As an alternative to directly using credentials, you can also use IAM instance profiles by
+setting `:use_iam_profile` to `true` in the deploy configuration.
+
 **Usage:**
 
 Tag your EC2 instances so you can target specific servers in your Capistrano configuration.

--- a/lib/capistrano/ec2/capistrano_monkey_patch.rb
+++ b/lib/capistrano/ec2/capistrano_monkey_patch.rb
@@ -3,7 +3,10 @@ require 'fog/aws'
 module Capistrano
   class Configuration
     def for_each_ec2_server(ec2_env:, ec2_role:, &block)
-      ec2 = Fog::Compute.new(provider: 'AWS', region: fetch(:region))
+      ec2 = Fog::Compute.new \
+        provider: 'AWS',
+        region: fetch(:region),
+        use_iam_profile: fetch(:use_iam_profile, false)
 
       filters = { "tag:ec2_env" => ec2_env, "tag:role" => ec2_role }
 


### PR DESCRIPTION
This adds a new `:use_iam_profile` option that can be set in the Capistrano
deploy configuration that makes fog attempt to use credentials gained
from the EC2 metadata service.