### PR TITLE
Add assume role support

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,16 +18,17 @@ Or install it yourself as:
 
     $ gem install capistrano-ec2
 
-## Usage
 
-**Requirements:**
+## Configuration
 
-Set the EC region in which your instances live in the Capistrano deploy configuration:
+Set the AWS region in which your instances live in the Capistrano deploy configuration:
 
-config/deploy.rb
+**config/deploy.rb**
 ```ruby
 set :region, 'us-west-2'
 ```
+
+### Using a credentials file
 
 Since it's a bad practice to have your credentials in source code, you should load them from default fog configuration file: `~/.fog`. This file could look like this:
 
@@ -37,10 +38,37 @@ default:
   aws_secret_access_key: <YOUR_SECRET_ACCESS_KEY>
 ```
 
-As an alternative to directly using credentials, you can also use IAM instance profiles by
-setting `:use_iam_profile` to `true` in the deploy configuration.
+### Using IAM instance profiles
 
-**Usage:**
+As an alternative to directly using credentials, you can also use IAM instance profiles by setting `:use_iam_profile` to `true` in the deploy configuration.
+
+**config/deploy.rb**
+```ruby
+set :use_iam_profile, true
+```
+
+### Using assume role configured in AWS configuration profile
+
+As an alternative to directly using credentials, you can configure capistrano-ec2 to assume a role by setting `:assume_role_using_profile` to the desired AWS profile in yuou configuration file that contains the role in its `role_arn` directive. This will use the instance its IAM Profile.
+
+**config/deploy.rb**
+```ruby
+set :assume_role_using_profile, '<profile_name>'
+```
+
+This will read the AWS profile configuration from `~/.aws/config` and is expecting the following profile defined:
+
+**~/.aws/config**
+```
+[profile <profile_name>]
+role_arn = arn:aws:iam::AWS_ACCOUNT:role/<some_role_name>
+credential_source = Ec2InstanceMetadata
+```
+
+The `role_arn` configured here will be the assumed role.
+
+
+## Usage
 
 Tag your EC2 instances so you can target specific servers in your Capistrano configuration.
 
@@ -48,6 +76,19 @@ Here is how to target all `production` `application-servers`:
 
 ```ruby
 for_each_ec2_server(ec2_env: "production", ec2_role: "application-server") do |ec2_server|
+  server ec2_server.private_ip_address, user: 'deploy', roles: roles
+end
+```
+
+### Tagging single server with additional role
+
+You'd probably want to have a single instance that is tagged with the "db" role. The seconds argument in the `do` block of `for_each_ec2_server` is the index of the current loop, you can use this as follows:
+
+```ruby
+for_each_ec2_server(ec2_env: "production", ec2_role: "application-server") do |ec2_server, index|
+  # Only add "db" role to the first server
+  roles = index.zero? ? %w(db app) : %w(app)
+
   server ec2_server.private_ip_address, user: 'deploy', roles: roles
 end
 ```

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ set :use_iam_profile, true
 
 ### Using assume role configured in AWS configuration profile
 
-As an alternative to directly using credentials, you can configure capistrano-ec2 to assume a role by setting `:assume_role_using_profile` to the desired AWS profile in yuou configuration file that contains the role in its `role_arn` directive. This will use the instance its IAM Profile.
+As an alternative to directly using credentials, you can configure capistrano-ec2 to assume a role by setting `:assume_role_using_profile` to the desired AWS profile in your configuration file that contains the role in its `role_arn` directive. This will use the instance its IAM Profile.
 
 **config/deploy.rb**
 ```ruby

--- a/capistrano-ec2.gemspec
+++ b/capistrano-ec2.gemspec
@@ -28,7 +28,8 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "capistrano", "~> 3.0"
-  spec.add_dependency "fog-aws", "~> 0.10.0"
+  spec.add_dependency "fog-aws", "~> 3.0"
+  spec.add_dependency "inifile", "~> 3.0"
 
   spec.add_development_dependency "bundler", "~> 1.12"
   spec.add_development_dependency "rake", "~> 10.0"

--- a/lib/assume_role_credential_fetcher.rb
+++ b/lib/assume_role_credential_fetcher.rb
@@ -1,0 +1,32 @@
+require 'fog/aws'
+require 'inifile'
+
+class AssumeRoleCredentialFetcher
+  DEFAULT_ROLE_SESSION_NAME = 'default_session'
+  PROFILE_FILE = "#{Dir.home}/.aws/config"
+
+  attr_reader :profile_name
+
+  def initialize(profile_name)
+    @profile_name = profile_name
+  end
+
+  def fetch_credentials
+    sts = Fog::AWS::STS.new(use_iam_profile: true)
+    sts.assume_role(DEFAULT_ROLE_SESSION_NAME, role_arn)
+  end
+
+  def role_arn
+    config_for_profile['role_arn']
+  end
+
+  def config_for_profile
+    ini_file = IniFile.load(PROFILE_FILE)
+    ini_file.to_h["profile #{profile_name}"]
+  end
+
+  def credentials
+    response = fetch_credentials
+    response.body
+  end
+end

--- a/lib/assume_role_credential_fetcher.rb
+++ b/lib/assume_role_credential_fetcher.rb
@@ -2,17 +2,20 @@ require 'fog/aws'
 require 'inifile'
 
 class AssumeRoleCredentialFetcher
+  DEFAULT_AWS_REGION='us-east-1'
   DEFAULT_ROLE_SESSION_NAME = 'default_session'
+
   PROFILE_FILE = "#{Dir.home}/.aws/config"
 
-  attr_reader :profile_name
+  attr_reader :profile_name, :region
 
-  def initialize(profile_name)
+  def initialize(profile_name, region=DEFAULT_AWS_REGION)
     @profile_name = profile_name
+    @region = region
   end
 
   def fetch_credentials
-    sts = Fog::AWS::STS.new(use_iam_profile: true)
+    sts = Fog::AWS::STS.new(use_iam_profile: true, region: region)
     sts.assume_role(DEFAULT_ROLE_SESSION_NAME, role_arn)
   end
 

--- a/lib/capistrano/ec2/capistrano_monkey_patch.rb
+++ b/lib/capistrano/ec2/capistrano_monkey_patch.rb
@@ -25,8 +25,8 @@ module Capistrano
 
     def for_each_ec2_server(ec2_env:, ec2_role:, &block)
       filters = {
-        "tag:ec2_env" => ec2_env,
-        "tag:role" => ec2_role,
+        "tag:ec2_env": ec2_env,
+        "tag:role": ec2_role,
         'instance-state-name': 'running'
       }
 

--- a/lib/capistrano/ec2/capistrano_monkey_patch.rb
+++ b/lib/capistrano/ec2/capistrano_monkey_patch.rb
@@ -1,17 +1,33 @@
 require 'fog/aws'
 
+require_relative('../../assume_role_credential_fetcher')
+
 module Capistrano
   class Configuration
-    def for_each_ec2_server(ec2_env:, ec2_role:, &block)
-      ec2 = Fog::Compute.new \
+    def ec2
+      configuration = {
         provider: 'AWS',
-        region: fetch(:region),
-        use_iam_profile: fetch(:use_iam_profile, false)
+        region: fetch(:region)
+      }
 
-      filters = { 
-        "tag:ec2_env" => ec2_env, 
-        "tag:role" => ec2_role, 
-        'instance-state-name': 'running' 
+      if assume_role_using_profile
+        assumed_role_credentials = AssumeRoleCredentialFetcher.new(assume_role_using_profile).credentials
+
+        configuration['aws_session_token'] = assumed_role_credentials['SessionToken']
+        configuration['aws_access_key_id'] = assumed_role_credentials['AccessKeyId']
+        configuration['aws_secret_access_key'] = assumed_role_credentials['SecretAccessKey']
+      else
+        configuration[:use_iam_profile] = fetch(:use_iam_profile, false)
+      end
+
+      Fog::Compute.new(configuration)
+    end
+
+    def for_each_ec2_server(ec2_env:, ec2_role:, &block)
+      filters = {
+        "tag:ec2_env" => ec2_env,
+        "tag:role" => ec2_role,
+        'instance-state-name': 'running'
       }
 
       ec2.servers.all(filters).map.with_index do |ec2_server, index|
@@ -19,6 +35,12 @@ module Capistrano
 
         yield ec2_server, index
       end
+    end
+
+    private
+
+    def assume_role_using_profile
+      @assume_role_using_profile ||= fetch(:assume_role_using_profile, false)
     end
   end
 

--- a/lib/capistrano/ec2/capistrano_monkey_patch.rb
+++ b/lib/capistrano/ec2/capistrano_monkey_patch.rb
@@ -5,13 +5,15 @@ require_relative('../../assume_role_credential_fetcher')
 module Capistrano
   class Configuration
     def ec2
+      region = fetch(:region)
+
       configuration = {
         provider: 'AWS',
-        region: fetch(:region)
+        region: region,
       }
 
       if assume_role_using_profile
-        assumed_role_credentials = AssumeRoleCredentialFetcher.new(assume_role_using_profile).credentials
+        assumed_role_credentials = AssumeRoleCredentialFetcher.new(assume_role_using_profile, region).credentials
 
         configuration['aws_session_token'] = assumed_role_credentials['SessionToken']
         configuration['aws_access_key_id'] = assumed_role_credentials['AccessKeyId']

--- a/lib/capistrano/ec2/version.rb
+++ b/lib/capistrano/ec2/version.rb
@@ -1,5 +1,5 @@
 module Capistrano
   module Ec2
-    VERSION = "0.1.3"
+    VERSION = "0.1.4"
   end
 end


### PR DESCRIPTION
Perform assume role using AWS STS using the profile configured in  :assume_role_using_profile. Expecting a “role_arn” configuration directive in the passed in profile section in ~/.aws/config. 

When the newly added configuration parameter is not set, fall back to default behavior. 